### PR TITLE
fix systemctl restart k3s failing

### DIFF
--- a/files/k3s.service
+++ b/files/k3s.service
@@ -11,7 +11,7 @@ NotifyAccess=all
 EnvironmentFile=-/etc/default/%N
 EnvironmentFile=-/etc/sysconfig/%N
 EnvironmentFile=-/etc/systemd/system/k3s.service.env
-KillMode=process
+KillMode=control-group
 Delegate=yes
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.


### PR DESCRIPTION
restarting the service fail, child processes not terminated. This change fixes the error.