### PR TITLE
Disable default service account

### DIFF
--- a/k3s.pkr.hcl
+++ b/k3s.pkr.hcl
@@ -33,9 +33,10 @@ source "googlecompute" "k3s" {
   image_family = regex_replace("k3s-${regex_replace(var.k3s_version, "\\+.*$", "")}", "[^a-zA-Z0-9_-]", "-")
   image_name   = regex_replace("k3s-${var.k3s_version}-${uuidv4()}", "[^a-zA-Z0-9_-]", "-")
 
-  source_image_family = "ubuntu-2204-lts"
-  machine_type        = "n1-standard-4"
-  disk_size           = 20
+  source_image_family             = "ubuntu-2204-lts"
+  machine_type                    = "n1-standard-4"
+  disk_size                       = 20
+  disable_default_service_account = true
 
   ssh_username = "root"
 }


### PR DESCRIPTION
Currently Packer's SA (`github-actions-custom-images@instruqt.iam.gserviceaccount.com`) needs to impersonate the default compute SA (`1095590792109-compute@developer.gserviceaccount.com`). For this, we need to grant `Service Account User` permission to the Packer's SA but because it's too dangerous, we need to harden the permission using IAM conditions. We tried various ways to limit Packer SA to **only** impersonate default compute SA but we couldn't succeed. Giving this option a change, in theory it should result in the usage of only Packer's SA. 

> disable_default_service_account (bool) - If true, the default service account will not be used if service_account_email is not specified. Set this value to true and omit service_account_email to provision a VM with no service account.