### PR TITLE
configure docker.registry.instruqt.io as registry mirror for docker.io

### DIFF
--- a/files/registries.yaml
+++ b/files/registries.yaml
@@ -1,0 +1,4 @@
+mirrors:
+  docker.io:
+    endpoint:
+      - "https://mirror.gcr.io"

--- a/files/registries.yaml
+++ b/files/registries.yaml
@@ -1,4 +1,4 @@
 mirrors:
   docker.io:
     endpoint:
-      - "https://mirror.gcr.io"
+      - "https://docker.registry.instruqt.io/"

--- a/k3s.pkr.hcl
+++ b/k3s.pkr.hcl
@@ -60,6 +60,10 @@ build {
     destination = "/etc/systemd/system/"
   }
 
+  provisioner "shell" {
+    inline = ["mkdir -p /etc/rancher/k3s/"]
+  }
+
   provisioner "file" {
     source      = "files/registries.yaml"
     destination = "/etc/rancher/k3s/registries.yaml"

--- a/k3s.pkr.hcl
+++ b/k3s.pkr.hcl
@@ -61,6 +61,11 @@ build {
   }
 
   provisioner "file" {
+    source      = "files/registries.yaml"
+    destination = "/etc/rancher/k3s/registries.yaml"
+  }
+
+  provisioner "file" {
     source      = "files/k3s-start.sh"
     destination = "/usr/local/bin/k3s-start.sh"
   }


### PR DESCRIPTION
Docker hub recently (2025-04) introduced very low image pull rate limits for unauthenticated users (100 pulls / 6 hours).
Our players run into this randomly.

GCP provides a registry mirror to avoid this rate limit, see https://cloud.google.com/artifact-registry/docs/pull-cached-dockerhub-images#configure


This MR configures mirror.gcr.io as mirror for docker.io, per instructions from https://docs.k3s.io/installation/private-registry.

In case the GCP cache does not have the image, K3S will still go to docker.io, but for common images this seems unlikely.

